### PR TITLE
Worker might die before killed

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -13,6 +13,10 @@
     ".coffee": "coffee-script"
   };
 
+  cluster.worker.on("disconnect", function() {
+    return setTimeout((function() {}), 0);
+  });
+
   cluster.worker.on("message", function(options) {
     var _load_orig, ext, main, module;
     main = path.resolve(process.cwd(), options.main);

--- a/lib/piping.js
+++ b/lib/piping.js
@@ -84,7 +84,7 @@
         for (id in ref) {
           worker = ref[id];
           respawnPending = true;
-          process.kill(worker.process.pid, 'SIGTERM');
+          worker.kill();
         }
         if (!respawnPending) {
           return cluster.fork();

--- a/src/launcher.coffee
+++ b/src/launcher.coffee
@@ -4,6 +4,11 @@ natives = ['assert','buffer','child_process','cluster','console','constants','cr
 languages =
   ".coffee":"coffee-script"
 
+# Allow registered process signal handlers to execute before exiting.
+# See https://github.com/nodejs/node/issues/4852.
+cluster.worker.on "disconnect", () ->
+  setTimeout((() ->), 0)
+
 cluster.worker.on "message", (options) ->
   main = path.resolve process.cwd(), options.main
   if options.hook

--- a/src/piping.coffee
+++ b/src/piping.coffee
@@ -71,7 +71,7 @@ module.exports = (ops) ->
       # if a worker is already running, kill it and let the exit handler respawn it
       for id, worker of cluster.workers
         respawnPending = true
-        process.kill(worker.process.pid, 'SIGTERM') # worker.kill() doesn't send SIGTERM
+        worker.kill()
 
       # if a worker died somehow, respawn it right away
       unless respawnPending


### PR DESCRIPTION
See #10.

This fix adds a no-op callback to the event queue via `setTimeout` to keep the worker alive so any exit handlers (`process.on('SIGTERM', ...)`) can be called (see nodejs/node#4852). Note that, depending on how the scheduler works, the worker may still exit too early.

This can be the case with `hapi`, the [fix](https://github.com/mdlawson/piping/commit/6e552d282e715596d64f7af22469b45807e84d91) for which I have reverted in this PR. If anybody experiences problems with for instance `hapi` not restarting correctly, we should put more energy in securing that exit handlers are called.
