### PR TITLE
Added an option to pass environment variables to the workers

### DIFF
--- a/lib/piping.js
+++ b/lib/piping.js
@@ -13,7 +13,8 @@
     includeModules: false,
     main: require.main.filename,
     ignore: /(\/\.|~$)/,
-    respawnOnExit: true
+    respawnOnExit: true,
+    env: {}
   };
 
   module.exports = function(ops) {
@@ -42,7 +43,7 @@
         interval: options.interval || 100,
         binaryInterval: options.binaryInterval || 300
       });
-      cluster.fork();
+      cluster.fork(options.env);
       respawnPending = false;
       lastErr = "";
       cluster.on("exit", function(dead, code, signal) {
@@ -54,7 +55,7 @@
           hasWorkers = true;
         }
         if (!hasWorkers && (respawnPending || options.respawnOnExit)) {
-          cluster.fork();
+          cluster.fork(options.env);
           return respawnPending = false;
         }
       });
@@ -87,7 +88,7 @@
           process.kill(worker.process.pid, 'SIGTERM');
         }
         if (!respawnPending) {
-          return cluster.fork();
+          return cluster.fork(options.env);
         }
       });
       return false;

--- a/src/piping.coffee
+++ b/src/piping.coffee
@@ -8,6 +8,7 @@ options =
     main: require.main.filename
     ignore: /(\/\.|~$)/
     respawnOnExit: true
+    env: {}
 
 module.exports = (ops) ->
   if typeof ops is "string" or ops instanceof String
@@ -34,7 +35,7 @@ module.exports = (ops) ->
       interval: options.interval || 100
       binaryInterval: options.binaryInterval || 300
 
-    cluster.fork()
+    cluster.fork options.env
     respawnPending = false
     lastErr = ""
 
@@ -45,7 +46,7 @@ module.exports = (ops) ->
         hasWorkers = true
 
       if !hasWorkers && (respawnPending || options.respawnOnExit)
-        cluster.fork()
+        cluster.fork options.env
         respawnPending = false
 
 
@@ -75,7 +76,7 @@ module.exports = (ops) ->
 
       # if a worker died somehow, respawn it right away
       unless respawnPending
-        cluster.fork()
+        cluster.fork options.env
 
     return false
   else


### PR DESCRIPTION
This PR adds a new `env` option, a simple key-value object to be passed to cluster.fork() in order to inject additional environment variables into the workers.
