### PR TITLE
Added options and logic to include filenames

### DIFF
--- a/lib/piping.js
+++ b/lib/piping.js
@@ -20,6 +20,7 @@ var cluster = require("cluster");
 var defaultOptions = {
   hook: false,
   firstChar: '.',
+  filenameStarts: [],
   includeModules: false,
   main: process.argv[1],
   args: process.argv.slice(2),
@@ -212,7 +213,16 @@ function piping(options, ready) {
         var file = module._resolveFilename(name, parent, isMain);
 
         // Ignore module files unless includeModules is set
-        if (name[0] === options.firstChar || options.includeModules && file.indexOf("node_modules") > 0) {
+        if ( // Include if name starts with a defined string
+        options.filenameStarts && options.filenameStarts.length > 0 && options.filenameStarts.reduce(function (prev, current) {
+          if (prev) return prev;
+          if (name.indexOf(current) > -1) {
+            return true;
+          }
+          return false;
+        }, false) || name[0] === options.firstChar || // include if name starts with a defined char
+        // include if modules are requested
+        options.includeModules && file.indexOf("node_modules") > 0) {
           worker.send({ file: file }); // Tell supervisor about the file
         }
 

--- a/lib/piping.js
+++ b/lib/piping.js
@@ -19,6 +19,7 @@ var EventEmitter = require("events");
 var cluster = require("cluster");
 var defaultOptions = {
   hook: false,
+  firstChar: '.',
   includeModules: false,
   main: process.argv[1],
   args: process.argv.slice(2),
@@ -211,7 +212,7 @@ function piping(options, ready) {
         var file = module._resolveFilename(name, parent, isMain);
 
         // Ignore module files unless includeModules is set
-        if (name[0] === "." || options.includeModules && file.indexOf("node_modules") > 0) {
+        if (name[0] === options.firstChar || options.includeModules && file.indexOf("node_modules") > 0) {
           worker.send({ file: file }); // Tell supervisor about the file
         }
 

--- a/src/piping.js
+++ b/src/piping.js
@@ -7,6 +7,7 @@ const EventEmitter = require("events");
 const cluster = require("cluster");
 const defaultOptions = {
   hook: false,
+  firstChar: '.',
   includeModules: false,
   main: process.argv[1],
   args: process.argv.slice(2),
@@ -191,7 +192,7 @@ export default function piping(options, ready) {
       const file = module._resolveFilename(name, parent, isMain);
 
       // Ignore module files unless includeModules is set
-      if (name[0] === "." || (options.includeModules && file.indexOf("node_modules") > 0)) {
+      if (name[0] === options.firstChar || (options.includeModules && file.indexOf("node_modules") > 0)) {
         worker.send({file}); // Tell supervisor about the file
       }
 

--- a/src/piping.js
+++ b/src/piping.js
@@ -8,6 +8,7 @@ const cluster = require("cluster");
 const defaultOptions = {
   hook: false,
   firstChar: '.',
+  filenameStarts: [],
   includeModules: false,
   main: process.argv[1],
   args: process.argv.slice(2),
@@ -192,7 +193,23 @@ export default function piping(options, ready) {
       const file = module._resolveFilename(name, parent, isMain);
 
       // Ignore module files unless includeModules is set
-      if (name[0] === options.firstChar || (options.includeModules && file.indexOf("node_modules") > 0)) {
+      if (
+        ( // Include if name starts with a defined string
+          options.filenameStarts &&
+          options.filenameStarts.length > 0 &&
+          options.filenameStarts.reduce((prev, current) => {
+            if (prev) return prev;
+            if (name.indexOf(current) > -1) {
+              return true;
+            }
+            return false;
+          }, false)
+        ) ||
+        name[0] === options.firstChar || // include if name starts with a defined char
+        ( // include if modules are requested
+          options.includeModules && file.indexOf("node_modules") > 0
+        )
+      ) {
         worker.send({file}); // Tell supervisor about the file
       }
 


### PR DESCRIPTION
This pull request is to allow specifying:

options.firstChar: '.'
and
options.filenameStarts: ['part','otherpart']

to include arbitrary names...

I personally use it like that:
{
    firstChar: null,
    filenameStarts: ['live']
}

in combination with webpack modulesDirectories when required files are specified like that:

import App from 'live/activecomponents/app/app.js';
