### PR TITLE
Fix ignoring resolved paths

### DIFF
--- a/lib/piping.js
+++ b/lib/piping.js
@@ -211,7 +211,7 @@ function piping(options, ready) {
         var file = module._resolveFilename(name, parent, isMain);
 
         // Ignore module files unless includeModules is set
-        if (name[0] === "." || options.includeModules && file.indexOf("node_modules") > 0) {
+        if (name[0] === "." || options.includeModules || file.indexOf("node_modules") === -1) {
           worker.send({ file: file }); // Tell supervisor about the file
         }
 

--- a/src/piping.js
+++ b/src/piping.js
@@ -191,7 +191,7 @@ export default function piping(options, ready) {
       const file = module._resolveFilename(name, parent, isMain);
 
       // Ignore module files unless includeModules is set
-      if (name[0] === "." || (options.includeModules && file.indexOf("node_modules") > 0)) {
+      if (name[0] === "." || options.includeModules || file.indexOf("node_modules") === -1) {
         worker.send({file}); // Tell supervisor about the file
       }
 


### PR DESCRIPTION
Due to checking for only if a path starts with `"."`, or if it was in
`node_modules`, this code never actually hot reloaded if the file was in
a resolved path.